### PR TITLE
If the bot sends a numeric message, Turntable broadcasts the event as num

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -294,7 +294,7 @@ Bot.prototype.roomInfo = function (callback) {
 };
 
 Bot.prototype.speak = function (msg, callback) {
-   var rq = { api: 'room.speak', roomid: this.roomId, text: msg };
+   var rq = { api: 'room.speak', roomid: this.roomId, text: msg.toString() };
    this._send(rq, callback);
 };
 


### PR DESCRIPTION
If the bot sends a numeric message, Turntable broadcasts the event as numeric. Not only will clients not display the message, but if the bot uses any string evaluations on incoming messages, an exception occurs.
