### PR TITLE
Make the version regex work with  non-release builds of node.js.

### DIFF
--- a/websocket.js
+++ b/websocket.js
@@ -36,7 +36,7 @@ var http = require('http');
 var net = require('net');
 var urllib = require('url');
 
-var reg = /^v0.([0-9]+).[0-9]+$/.exec(process.version);
+var reg = /^v0.([0-9]+).[0-9]+(-pre)?$/.exec(process.version);
 var oldVersion = reg ? +reg[1] <= 4 : false;
 var sys = oldVersion ? require('sys') : require('util');
 


### PR DESCRIPTION
Non-release node.js binaries build with NODE_PATCH_VERSION "-pre".
Enable this suffix to be present when matching the process.version string.
