### PR TITLE
Added trailing comma, removed 3 blank lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "index.js",
   "scripts": {
     "start": "./examples/chat_bot.js"
-  }
+  },
   "engines": {
     "node": ">= v0.4.0"
   },


### PR DESCRIPTION
Fixes extra line error in node v6.6.6 on Windows 32-bit builds
