### PR TITLE
Change to handle incorrect server response

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -328,7 +328,12 @@ Bot.prototype.which_server = function (roomid, callback) {
          dataStr += chunk.toString();
       });
       res.on('end', function () {
-         var data = JSON.parse(dataStr);
+         var data;
+         try {
+            data = JSON.parse(dataStr);
+         } catch (e) {
+            data = [];
+         }
          if (data[0]) {
             callback.call(self, data[1].chatserver[0], data[1].chatserver[1]);
          } else if (self.debug) {


### PR DESCRIPTION
During one of the Turntable outages several weeks ago, I noticed that the server was responding with status code 302 to the request in the which_server method. This change wraps the JSON.parse() call in a try-catch so that we can handle the condition gracefully.
