### PR TITLE
Python: Changing isinstance str to basestring

### DIFF
--- a/python_ttapi/ttapi.py
+++ b/python_ttapi/ttapi.py
@@ -329,7 +329,7 @@ class Bot:
          if callable(args[0]):
             djId = None
             callback = args[0]
-         elif isinstance(args[0], str):
+         elif isinstance(args[0], basestring):
             djId = args[0]
             callback = None
       elif len(args) == 2:
@@ -414,7 +414,7 @@ class Bot:
       if len(args) == 1:
          if callable(args[0]):
             callback = args[0]
-         elif isinstance(args[0], str):
+         elif isinstance(args[0], basestring):
             rq['userid'] = args[0]
       elif len(args) == 2:
          rq['userid'] = args[0]
@@ -463,7 +463,7 @@ class Bot:
       playlistName = 'default'
       callback = None
       if len(args) == 1:
-         if isinstance(args[0], str): playlistName = args[0]
+         if isinstance(args[0], basestring): playlistName = args[0]
          if callable(args[0]):        callback     = args[0]
       elif len(args) == 2:
          playlistName = args[0]
@@ -480,31 +480,31 @@ class Bot:
       if len(args) == 1:
          songId = args[0]
       elif len(args) == 2:
-         if isinstance(args[0], str) and isinstance(args[1], str):
+         if isinstance(args[0], basestring) and isinstance(args[1], basestring):
             playlistName = args[0]
             songId       = args[1]
-         elif isinstance(args[0], str) and callable(args[1]):
+         elif isinstance(args[0], basestring) and callable(args[1]):
             songId   = args[0]
             callback = args[1]
-         elif isinstance(args[0], str) and isinstance(args[1], int):
+         elif isinstance(args[0], basestring) and isinstance(args[1], int):
             songId = args[0]
             index  = args[1]
-         elif isinstance(args[0], bool) and isinstance(args[1], str):
+         elif isinstance(args[0], bool) and isinstance(args[1], basestring):
             songId = args[1]
       elif len(args) == 3:
-         if isinstance(args[0], str) and isinstance(args[1], str) and isinstance(args[2], int):
+         if isinstance(args[0], basestring) and isinstance(args[1], basestring) and isinstance(args[2], int):
             playlistName = args[0]
             songId       = args[1]
             index        = args[2]
-         elif isinstance(args[0], str) and isinstance(args[1], str) and callable(args[2]):
+         elif isinstance(args[0], basestring) and isinstance(args[1], basestring) and callable(args[2]):
             playlistName = args[0]
             songId       = args[1]
             callback     = args[2]
-         elif isinstance(args[0], str) and isinstance(args[1], int) and callable(args[2]):
+         elif isinstance(args[0], basestring) and isinstance(args[1], int) and callable(args[2]):
             songId   = args[0]
             index    = args[1]
             callback = args[2]
-         elif isinstance(args[0], bool) and isinstance(args[1], str) and callable(args[2]):
+         elif isinstance(args[0], bool) and isinstance(args[1], basestring) and callable(args[2]):
             songId   = args[1]
             callback = args[2]
       elif len(args) == 4:
@@ -524,7 +524,7 @@ class Bot:
       if len(args) == 1:
          index = args[0]
       elif len(args) == 2:
-         if isinstance(args[0], str) and isinstance(args[1], int):
+         if isinstance(args[0], basestring) and isinstance(args[1], int):
             playlistName = args[0]
             index        = args[1]
          elif isinstance(args[0], int) and callable(args[1]):
@@ -547,7 +547,7 @@ class Bot:
          indexFrom = args[0]
          indexTo   = args[1]
       elif len(args) == 3:
-         if isinstance(args[0], str) and isinstance(args[1], int) and isinstance(args[2], int):
+         if isinstance(args[0], basestring) and isinstance(args[1], int) and isinstance(args[2], int):
             playlistName = args[0]
             indexFrom    = args[1]
             indexTo      = args[2]


### PR DESCRIPTION
basestring checks if the value is a str or unicode type so that either can be used because unicode data is sent to the bot. Unicodes don't register in Python as strings but unicodes register as basestring types. Since unicodes are sent, unicode data cannot be shipped back because unicodes won't register as strings in the API.
Eg:

``` python
def newSong(data):
    global genre,artist,lameGenres,lameArtists
    songData = data['room']['metadata']['current_song']
    DJid = songData['djid']  # THIS DATA IS A UNICODE TYPE!
    artist = songData['metadata']['artist']
    genre = songData['metadata']['genre']
    for i in range(len(lameGenres)): # Note: for loop is used because lameGenres contains substrings of disallowed genres in case there are 2 different genres such as "Rap" and "Rap/Hip Hop"
        if lameGenres[i].lower() in genre.lower():
            eebot.remDj(DJid) # REMDJ WILL NOT WORK WITH UNICODE TYPES!
            eebot.speak('%s is not allowed!' % genre)
            break
    for i in range(len(lameArtists)):
        if lameArtists[i].lower() in artist.lower():
            eebot.remDj(DJid) # SAME AS ABOVE
            eebot.speak('This kind of music is not allowed!')
            break
```

TLDR: basestring checks for str and unicode types
