### PR TITLE
Additional parameter to stopSong

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -673,7 +673,8 @@
       var rq;
       rq = {
         api: 'room.stop_song',
-        roomid: this.roomId
+        roomid: this.roomId,
+        current_song: this.currentSongId
       };
       return this._send(rq, callback);
     };


### PR DESCRIPTION
Add current_song parameter to stopSong method, which Turntable will now require to prevent issues of "double-skipping" when the current DJ skips a song at the same time an SU is forcing one.
