### PR TITLE
Additional parameter to stopSong (in coffeescript)

### DIFF
--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -500,7 +500,7 @@ class Bot
 
 
   stopSong: (callback) ->
-    rq = api: 'room.stop_song', roomid: @roomId
+    rq = api: 'room.stop_song', roomid: @roomId, current_song: @currentSongId
     @_send rq, callback
 
 


### PR DESCRIPTION
Add current_song parameter to stopSong method, which Turntable will now require to prevent issues of "double-skipping" when the current DJ skips a song at the same time an SU is forcing one.
