### PR TITLE
Update getProfile() API method call

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -830,7 +830,7 @@
     Bot.prototype.getProfile = function() {
       var callback, rq;
       rq = {
-        api: 'user.get_profile'
+        api: 'user.get_profile_info'
       };
       callback = null;
       if (arguments.length === 1) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "name": "ttapi",
   "description": "A turntable.fm API",
   "keywords": ["turntable.fm", "turntable", "stickybits", "realtime"],
-  "version": "2.1.7",
+  "version": "2.1.8",
   "repository": {
     "type": "git",
     "url": "git://github.com/alaingilbert/Turntable-API.git"

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -620,7 +620,7 @@ class Bot
 
 
   getProfile: ->
-    rq = api: 'user.get_profile'
+    rq = api: 'user.get_profile_info'
     callback = null
     if arguments.length == 1
       if typeof arguments[0] == 'function'


### PR DESCRIPTION
Updates the bot.getProfile() command to call the "user.get_profile_info" API instead of "user.get_profile". This fixes sharedferret/Sparkle-Turntable-Bot#100 - the user.get_profile API call (as currently written in ttapi) will always return the bot's profile, whereas user.get_profile_info will return the input user's profile.
