### PR TITLE
Unhandled exception fix

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -100,7 +100,7 @@
             _ref = data[1].chatserver, host = _ref[0], port = _ref[1];
             return callback.call(self, host, port);
           } else {
-            return this.log("Failed to determine which server to use: " + dataStr);
+            return self.log("Failed to determine which server to use: " + dataStr);
           }
         });
       });

--- a/src/bot.coffee
+++ b/src/bot.coffee
@@ -98,7 +98,7 @@ class Bot
           [host, port] = data[1].chatserver
           callback.call(self, host, port)
         else
-          @log "Failed to determine which server to use: #{dataStr}"
+          self.log "Failed to determine which server to use: #{dataStr}"
 
 
   setTmpSong: (data) ->


### PR DESCRIPTION
There's a closure problem in whichServer() that causes an unhandled exception when the server can't be found (as is presently the case, as I write this). This is a trivial patch to fix the problem.
