### PR TITLE
Update the stopSong method to allow skipping someone else's song

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Remove the specified DJ, or yourself if not specified.
 
 ### stopSong ( [callback:fn] )
 
-Stop the song you are currently playing.
+Stop the currently playing song. You must be a moderator to stop playing someone else's song.
 
 ###### Note
 

--- a/src/bot.js
+++ b/src/bot.js
@@ -674,7 +674,12 @@ class Bot extends EventEmitter {
 
 
   stopSong(callback) {
-    const rq = {api: 'room.stop_song', roomid: this.roomId, current_song: this.currentSongId};
+    const rq = {
+      api: 'room.stop_song',
+      djid: this.currentDjId,
+      roomid: this.roomId,
+      current_song: this.currentSongId
+    };
     return this._send(rq, callback);
   }
 


### PR DESCRIPTION
The API has been updated to allow moderators to skip the currently playing song for anyone on the table.

If you do not have the required privileges, the API will return an error.